### PR TITLE
feat: use latest Harvest image

### DIFF
--- a/harvest/harvest.yml
+++ b/harvest/harvest.yml
@@ -1,9 +1,10 @@
-
+Tools:
+  # add tools here
+  
 Exporters:
   Harvest:
-    exporter: prometheus
+    exporter: Prometheus
     addr: 0.0.0.0
-    master: True
 
 Defaults:
   collectors:
@@ -13,21 +14,14 @@ Defaults:
     - Harvest
   use_insecure_tls: true
 
+# add your Cdot / 7Mode pollers below
+
 Pollers:
-  #unix:
-  #  datacenter: local
-  #  addr: localhost
-  #  collectors:
-  #    - Unix
-  #  exporters:
-  #    - prometheus
-
-  # add your Cdot / 7Mode pollers below, example:
-
   cluster-1:
     datacenter: DC1
     addr: 192.168.55.151
     auth_style: basic_auth
-    prometheus_port: 25000
     username: admin-username
     password: admin-password
+    ansible_port: 25001
+

--- a/manage_harvest.yml
+++ b/manage_harvest.yml
@@ -13,13 +13,13 @@
       source: pull
     loop:
     - prom/prometheus
-    - schmots1/na_harvest
+    - rahulguptajss/harvest
     - grafana/grafana
     tags: setup
   - name: Configure/Verify Prometheus targets
     lineinfile:
       path: ./prometheus/prometheus.yml
-      line: "  - targets: ['harvest_{{ item }}:{{Pollers[item].prometheus_port}}']"
+      line: "  - targets: ['harvest_{{ item }}:{{Pollers[item].ansible_port}}']"
     loop: "{{ Pollers|list }}"
   - name: Create Harvest Network
     docker_network:
@@ -58,12 +58,12 @@
   - name: Setup/verify Harvest pollers
     docker_container:
       name: "harvest_{{ item }}"
-      image: schmots1/na_harvest
+      image: rahulguptajss/harvest
       restart_policy: unless-stopped
       volumes:
       - ./harvest/:/etc/harvest/
       command:
-      - "{{ Pollers[item].prometheus_port}} -p {{ item }}"
+      - "--config /etc/harvest/harvest.yml -p {{ item }} --promPort {{ Pollers[item].ansible_port}}"
       networks:
       - name: harvest
       detach: true
@@ -93,11 +93,9 @@
   - name: Prep Grafana dashboard load 
     lineinfile:
       path: ./harvest/harvest.yml
-      line: "{{ item }}"
-      insertbefore: BOF
-    loop:
-    - "  grafana_api_token: {{ login.json.key }}"
-    - "Tools:"
+      insertafter: '^Tools:'
+      regexp: '  grafana_api_token:'
+      line: '  grafana_api_token: {{ login.json.key }}'
     tags: never, api     
   - name: Add Dashboards to Grafana
     docker_container_exec:
@@ -119,7 +117,7 @@
   - name: Stop Harvest pollers
     docker_container:
       name: "harvest_{{ item }}"
-      image: schmots1/na_harvest
+      image: rahulguptajss/harvest
       state: stopped
       detach: true
     loop: "{{ Pollers|list}}" 
@@ -142,19 +140,19 @@
     tags: never, del, upgrade
   - name: update images
     docker_image:
-      name: schmots1/na_harvest
+      name: rahulguptajss/harvest
       force_source: true
       source: pull
     tags: never, upgrade
   - name: Update Harvest pollers
     docker_container:
       name: "harvest_{{ item }}"
-      image: schmots1/na_harvest
+      image: rahulguptajss/harvest
       restart: true
       volumes:
       - ./harvest/:/etc/harvest/
       command:
-      - "{{ Pollers[item].prometheus_port}} -p {{ item }}"
+      - "--config /etc/harvest/harvest.yml -p {{ item }} --promPort {{ Pollers[item].ansible_port}}"
       networks:
       - name: harvest
       detach: true


### PR DESCRIPTION
This change pulls the latest build of Harvest from Dockerhub and
fixes a few bugs in the included harvest.yml:
* exporter case was incorrect causing exporter to fail at startup
* removed unused key/value pairs to avoid confusion.

Exporters/name/master is not used by Harvest

Renamed prometheus_port to ansible_port since prometheus_port is not a
key that Harvest supports; that key is for the Ansible script.